### PR TITLE
Allow custom user agent and base URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,15 +133,16 @@ func (c *Client) NewRequest(method, path string, body interface{}) (*http.Reques
 	return req, nil
 }
 
-// setUserAgent is a config function allowing setting of the User-Agent header in requests
-func setUserAgent(userAgentString string) func(*Client) error {
+// SetUserAgent is a config function allowing setting of the User-Agent header in requests
+func SetUserAgent(userAgentString string) func(*Client) error {
 	return func(c *Client) error {
 		c.userAgentString = userAgentString
 		return nil
 	}
 }
 
-func setBaseURL(urlString string) func(*Client) error {
+// SetBaseURL is a config function allowing setting of the base URL the API is on
+func SetBaseURL(urlString string) func(*Client) error {
 	return func(c *Client) error {
 		var altURL *url.URL
 		var err error

--- a/client_test.go
+++ b/client_test.go
@@ -35,14 +35,14 @@ func TestNewClient_Customized(t *testing.T) {
 	altBaseURLString := "https://api.librato.com"
 
 	t.Run("custom user agent string", func(t *testing.T) {
-		c := NewClient(token, setUserAgent(altUserAgentString))
+		c := NewClient(token, SetUserAgent(altUserAgentString))
 		if c.userAgentString != altUserAgentString {
 			t.Errorf("expected '%s' to match '%s'", c.userAgentString, altUserAgentString)
 		}
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		c := NewClient(token, setBaseURL(altBaseURLString))
+		c := NewClient(token, SetBaseURL(altBaseURLString))
 		testAltBaseURL, _ := url.Parse(altBaseURLString)
 		if *c.baseURL != *testAltBaseURL {
 			t.Errorf("expected '%s' to match '%s'", *c.baseURL, *testAltBaseURL)

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,51 @@
+package appoptics
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNewClient_Defaults(t *testing.T) {
+	token := "deadbeef"
+	c := NewClient(token)
+
+	t.Run("token should be set to passed-in value", func(t *testing.T) {
+		if c.token != token {
+			t.Errorf("expected '%s' to match '%s'", c.token, token)
+		}
+	})
+
+	t.Run("baseURL should be set to default", func(t *testing.T) {
+		clientURL, _ := url.Parse(defaultBaseURL)
+		if *c.baseURL != *clientURL {
+			t.Errorf("expected '%s' to match '%s'", *c.baseURL, *clientURL)
+		}
+	})
+
+	t.Run("userAgentString should be set to default", func(t *testing.T) {
+		if c.userAgentString != defaultUserAgentString {
+			t.Errorf("expected '%s' to match '%s'", c.userAgentString, defaultUserAgentString)
+		}
+	})
+}
+
+func TestNewClient_Customized(t *testing.T) {
+	token := "deadbeef"
+	altUserAgentString := "totally-different-thing"
+	altBaseURLString := "https://api.librato.com"
+
+	t.Run("custom user agent string", func(t *testing.T) {
+		c := NewClient(token, setUserAgent(altUserAgentString))
+		if c.userAgentString != altUserAgentString {
+			t.Errorf("expected '%s' to match '%s'", c.userAgentString, altUserAgentString)
+		}
+	})
+
+	t.Run("custom base URL", func(t *testing.T) {
+		c := NewClient(token, setBaseURL(altBaseURLString))
+		testAltBaseURL, _ := url.Parse(altBaseURLString)
+		if *c.baseURL != *testAltBaseURL {
+			t.Errorf("expected '%s' to match '%s'", *c.baseURL, *testAltBaseURL)
+		}
+	})
+}


### PR DESCRIPTION
 Fixes #19

## What
Allow user to set their own user agent string and base URL

## Why
To help w/ integrations in other projects and allow people to use this client w/ the legacy Librato REST API
