### PR TITLE
Set Time to MS

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -117,6 +117,7 @@ func (r *Reporter) flushReport(report *MeasurementSetReport) {
 		m := Measurement{
 			Name: r.prefix + regexpIllegalNameChars.ReplaceAllString(metricName, "_"),
 			Tags: r.mergeGlobalTags(tags),
+			Time: time.Now().UTC().Unix(),
 		}
 		if agg.Sum != 0 {
 			m.Sum = agg.Sum


### PR DESCRIPTION
Set Time to MS to prevent server denial when measurement set doesn't  contain any data except aggregation.
For MSs with unset time and no other data being reported, I was getting server errors that time "Is too old"