### PR TITLE
use Time.Now().UTC() in flushReporter

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -77,7 +77,7 @@ func (r *Reporter) postMeasurementBatches() {
 }
 
 func (r *Reporter) flushReport(report *MeasurementSetReport) {
-	batchTimeUnixSecs := (time.Now().Unix() / outputMeasurementsIntervalSeconds) * outputMeasurementsIntervalSeconds
+	batchTimeUnixSecs := (time.Now().UTC().Unix() / outputMeasurementsIntervalSeconds) * outputMeasurementsIntervalSeconds
 
 	var batch *MeasurementsBatch
 	resetBatch := func() {


### PR DESCRIPTION
I noticed we are using Time.Now().UTC() in other places, just not here. Alternative to #28.