### PR TITLE
Allow empty "time" field in Measurement POST

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,7 +72,7 @@ type Client struct {
 	// baseURL is the base endpoint of the remote  service
 	baseURL *url.URL
 	// httpClient is the http.Client singleton used for wire interaction
-	httpClient *http.Client
+	httpClient httpClient
 	// token is the private part of the API credential pair
 	token string
 	// measurementsService embeds the httpClient and implements access to the Measurements API
@@ -81,6 +81,11 @@ type Client struct {
 	spacesService SpacesCommunicator
 	// callerUserAgentFragment is placed in the User-Agent header
 	callerUserAgentFragment string
+}
+
+// httpClient defines the http.Client method used by Client.
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // ClientOption provides functional option-setting behavior

--- a/measurements.go
+++ b/measurements.go
@@ -18,7 +18,7 @@ type Measurement struct {
 	Name       string                 `json:"name"`
 	Tags       map[string]string      `json:"tags,omitempty"`
 	Value      interface{}            `json:"value,omitempty"`
-	Time       int64                  `json:"time"` //,omitempty"`
+	Time       int64                  `json:"time,omitempty"`
 	Count      interface{}            `json:"count,omitempty"`
 	Sum        interface{}            `json:"sum,omitempty"`
 	Min        interface{}            `json:"min,omitempty"`

--- a/measurements.go
+++ b/measurements.go
@@ -18,7 +18,7 @@ type Measurement struct {
 	Name       string                 `json:"name"`
 	Tags       map[string]string      `json:"tags,omitempty"`
 	Value      interface{}            `json:"value,omitempty"`
-	Time       int64                  `json:"time"`
+	Time       int64                  `json:"time"` //,omitempty"`
 	Count      interface{}            `json:"count,omitempty"`
 	Sum        interface{}            `json:"sum,omitempty"`
 	Min        interface{}            `json:"min,omitempty"`

--- a/measurements_test.go
+++ b/measurements_test.go
@@ -1,0 +1,96 @@
+package appoptics
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockHTTPClient struct {
+	t    *testing.T
+	reqs []*http.Request
+}
+
+var errMockHTTPClientExpected = errors.New("mock http.Response not implemented")
+
+func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.reqs = append(c.reqs, req)
+	return nil, errMockHTTPClientExpected
+}
+
+// Test Create works by using a mock HTTP client and checking the request resulting from
+// posting a MeasurementsBatch.
+func TestMeasurementsServiceCreate(t *testing.T) {
+	// prep batch
+	ts1 := time.Now().Unix()
+	ts2 := time.Now().Unix() - 100
+
+	testBatch := &MeasurementsBatch{
+		Measurements: []Measurement{
+			{Name: "metric1", Tags: map[string]string{"a": "b"}, Value: 5},
+			{Name: "metric2", Tags: map[string]string{"c": "d"}, Sum: 10, Count: 2},
+			{Name: "metric3", Tags: map[string]string{"x": "y"}, Value: 4, Time: ts1},
+		},
+		Period: 60,
+		Time:   ts2,
+		Tags:   &map[string]string{"j": "k", "l": "m"},
+	}
+
+	// post batch
+	mockClient := &mockHTTPClient{t: t}
+	baseURL := "http://unused:8383/v1/" // XXX remove /v1/ from baseURL
+	c := NewClient("abcdef", BaseURLClientOption(baseURL))
+	c.httpClient = mockClient
+	ms := &MeasurementsService{client: c}
+	resp, err := ms.Create(testBatch)
+	assert.Nil(t, resp)
+	assert.Equal(t, errMockHTTPClientExpected, err)
+
+	// assert expected http.Request
+	require.Len(t, mockClient.reqs, 1)
+	req := mockClient.reqs[0]
+	assert.Equal(t, "POST", req.Method)
+	assert.Equal(t, "unused:8383", req.URL.Host)
+	assert.Equal(t, "/v1/measurements", req.URL.Path)
+
+	// unmarshal JSON and assert
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(req.Body)
+	assert.NoError(t, err)
+	data := make(map[string]interface{})
+	err = json.Unmarshal(buf.Bytes(), &data)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, 60, data["period"])
+	assert.EqualValues(t, ts2, data["time"])
+	assert.Equal(t, map[string]interface{}{"j": "k", "l": "m"}, data["tags"])
+
+	mts, ok := data["measurements"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, mts, len(testBatch.Measurements))
+
+	m0, ok := mts[0].(map[string]interface{})
+	assert.Equal(t, "metric1", m0["name"])
+	assert.Equal(t, map[string]interface{}{"a": "b"}, m0["tags"])
+	assert.EqualValues(t, 5, m0["value"])
+	assert.NotContains(t, m0, "time")
+
+	m1, ok := mts[1].(map[string]interface{})
+	assert.Equal(t, "metric2", m1["name"])
+	assert.Equal(t, map[string]interface{}{"c": "d"}, m1["tags"])
+	assert.EqualValues(t, 10, m1["sum"])
+	assert.EqualValues(t, 2, m1["count"])
+	assert.NotContains(t, m1, "time")
+
+	m2, ok := mts[2].(map[string]interface{})
+	assert.Equal(t, "metric3", m2["name"])
+	assert.Equal(t, map[string]interface{}{"x": "y"}, m2["tags"])
+	assert.EqualValues(t, 4, m2["value"])
+	assert.EqualValues(t, ts1, m2["time"])
+}

--- a/measurements_test.go
+++ b/measurements_test.go
@@ -80,6 +80,10 @@ func TestMeasurementsServiceCreate(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"a": "b"}, m0["tags"])
 	assert.EqualValues(t, 5, m0["value"])
 	assert.NotContains(t, m0, "time")
+	assert.NotContains(t, m0, "sum")
+	assert.NotContains(t, m0, "count")
+	assert.NotContains(t, m0, "min")
+	assert.NotContains(t, m0, "max")
 
 	m1, ok := mts[1].(map[string]interface{})
 	assert.Equal(t, "metric2", m1["name"])
@@ -87,10 +91,15 @@ func TestMeasurementsServiceCreate(t *testing.T) {
 	assert.EqualValues(t, 10, m1["sum"])
 	assert.EqualValues(t, 2, m1["count"])
 	assert.NotContains(t, m1, "time")
+	assert.NotContains(t, m1, "value")
 
 	m2, ok := mts[2].(map[string]interface{})
 	assert.Equal(t, "metric3", m2["name"])
 	assert.Equal(t, map[string]interface{}{"x": "y"}, m2["tags"])
 	assert.EqualValues(t, 4, m2["value"])
 	assert.EqualValues(t, ts1, m2["time"])
+	assert.NotContains(t, m2, "sum")
+	assert.NotContains(t, m2, "count")
+	assert.NotContains(t, m2, "min")
+	assert.NotContains(t, m2, "max")
 }


### PR DESCRIPTION
Test case to address #28 and allow for empty "time" fields in the Measurement array in the POST body.