### PR TITLE
gRPC Metrics Interceptor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.10
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/contrib/grpc/interceptors.go
+++ b/contrib/grpc/interceptors.go
@@ -12,71 +12,63 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type instrumentedServer struct {
+type InstrumentedServer struct {
 	m       *appoptics.MeasurementSet
 	service string
 	method  string
 	tags    map[string]interface{}
 }
 
-func newInstrumentedServer(m *appoptics.MeasurementSet, service, method string, tags map[string]interface{}) *instrumentedServer {
-	return &instrumentedServer{
-		m:       m,
-		service: service,
-		method:  method,
-		tags:    tags,
-	}
-}
-
-func (s *instrumentedServer) key(key string) string {
+func (s *InstrumentedServer) key(key string) string {
 	return appoptics.MetricWithTags(fmt.Sprintf("%s.%s.%s", s.service, s.method, key), s.tags)
 }
 
-func (s *instrumentedServer) sent() {
+func (s *InstrumentedServer) sent() {
 	s.m.Incr(s.key("sent"))
 }
 
-func (s *instrumentedServer) received() {
+func (s *InstrumentedServer) received() {
 	s.m.Incr(s.key("received"))
 }
 
-func (s *instrumentedServer) handled(err error) {
-	s.m.Incr(s.key(status.Code(err).String()))
+func (s *InstrumentedServer) handled(err error) {
+	s.tags["status"] = status.Code(err).String()
+	s.m.Incr(s.key("result"))
 }
 
-func (s *instrumentedServer) timed(t time.Duration) {
+func (s *InstrumentedServer) timed(t time.Duration) {
 	s.m.UpdateAggregatorValue(s.key("time_ms"), float64(t/time.Millisecond)+float64(t%time.Millisecond)/1e9)
 }
 
-type instrumentedServerStream struct {
+type InstrumentedServerStream struct {
 	grpc.ServerStream
-	*instrumentedServer
+	InstrumentedServer
 }
 
-func (s *instrumentedServerStream) SendMsg(m interface{}) error {
+func (s *InstrumentedServerStream) SendMsg(m interface{}) error {
 	err := s.ServerStream.SendMsg(m)
 	if err == nil {
-		s.instrumentedServer.sent()
+		s.InstrumentedServer.sent()
 	}
 	return err
 }
 
-func (s *instrumentedServerStream) RecvMsg(m interface{}) error {
+func (s *InstrumentedServerStream) RecvMsg(m interface{}) error {
 	err := s.ServerStream.RecvMsg(m)
 	if err == nil {
-		s.instrumentedServer.received()
+		s.InstrumentedServer.received()
 	}
 	return err
 }
 
 func UnaryServerInterceptor(m *appoptics.MeasurementSet) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		instrument := newInstrumentedServer(
+		instrument := InstrumentedServer{
 			m,
 			path.Dir(info.FullMethod)[1:],
 			path.Base(info.FullMethod),
 			ctxtags.Extract(ctx).Values(),
-		)
+		}
 
 		instrument.received()
 
@@ -95,14 +87,14 @@ func UnaryServerInterceptor(m *appoptics.MeasurementSet) grpc.UnaryServerInterce
 
 func StreamServerInterceptor(m *appoptics.MeasurementSet) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		instrument := &instrumentedServerStream{
+		instrument := &InstrumentedServerStream{
 			ss,
-			newInstrumentedServer(
+			InstrumentedServer{
 				m,
 				path.Dir(info.FullMethod)[1:],
 				path.Base(info.FullMethod),
 				nil,
-			),
+			},
 		}
 
 		start := time.Now()

--- a/contrib/grpc/interceptors.go
+++ b/contrib/grpc/interceptors.go
@@ -1,0 +1,118 @@
+package interceptors
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/appoptics/appoptics-api-go"
+	ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+type instrumentedServer struct {
+	m       *appoptics.MeasurementSet
+	service string
+	method  string
+	tags    map[string]interface{}
+}
+
+func newInstrumentedServer(m *appoptics.MeasurementSet, service, method string, tags map[string]interface{}) *instrumentedServer {
+	return &instrumentedServer{
+		m:       m,
+		service: service,
+		method:  method,
+		tags:    tags,
+	}
+}
+
+func (s *instrumentedServer) key(key string) string {
+	return appoptics.MetricWithTags(fmt.Sprintf("%s.%s.%s", s.service, s.method, key), s.tags)
+}
+
+func (s *instrumentedServer) sent() {
+	s.m.Incr(s.key("sent"))
+}
+
+func (s *instrumentedServer) received() {
+	s.m.Incr(s.key("received"))
+}
+
+func (s *instrumentedServer) handled(err error) {
+	s.m.Incr(s.key(grpc.Code(err).String()))
+}
+
+func (s *instrumentedServer) timed(t float64) {
+	s.m.UpdateAggregatorValue(s.key("time_ms"), t)
+}
+
+type instrumentedServerStream struct {
+	grpc.ServerStream
+	*instrumentedServer
+}
+
+func (s *instrumentedServerStream) SendMsg(m interface{}) error {
+	err := s.ServerStream.SendMsg(m)
+	if err == nil {
+		s.instrumentedServer.sent()
+	}
+	return err
+}
+
+func (s *instrumentedServerStream) RecvMsg(m interface{}) error {
+	err := s.ServerStream.RecvMsg(m)
+	if err == nil {
+		s.instrumentedServer.received()
+	}
+	return err
+}
+
+func UnaryServerInterceptor(m *appoptics.MeasurementSet) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		instrument := newInstrumentedServer(
+			m,
+			path.Dir(info.FullMethod)[1:],
+			path.Base(info.FullMethod),
+			ctxtags.Extract(ctx).Values(),
+		)
+
+		instrument.received()
+
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		durationMs := time.Now().Sub(start) / time.Millisecond
+
+		instrument.timed(durationMs)
+		instrument.handled(err)
+
+		if err == nil {
+			instrument.sent()
+		}
+
+		return resp, err
+	}
+}
+
+func StreamServerInterceptor(m *appoptics.MeasurementSet) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		instrument := &instrumentedServerStream{
+			ss,
+			newInstrumentedServer(
+				m,
+				path.Dir(info.FullMethod)[1:],
+				path.Base(info.FullMethod),
+				nil,
+			),
+		}
+
+		start := time.Now()
+		err := handler(srv, instrument)
+		durationMs := time.Now().Sub(start) / time.Millisecond
+
+		instrument.handled(err)
+		instrument.timed(durationMs)
+
+		return err
+	}
+}

--- a/contrib/grpc/interceptors_test.go
+++ b/contrib/grpc/interceptors_test.go
@@ -1,0 +1,35 @@
+package interceptors
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"github.com/appoptics/appoptics-api-go"
+	"github.com/stretchr/testify/assert"
+	"fmt"
+	"strings"
+)
+
+var (
+	srv = "server_full_of_testing"
+	uInfo = &grpc.UnaryServerInfo{
+		FullMethod: "/something/blah",
+		Server:     srv,
+	}
+)
+
+func TestUnaryRequest(t *testing.T) {
+	measures := appoptics.NewMeasurementSet()
+	intercept := UnaryServerInterceptor(measures)
+	ctx := context.Background()
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "something", nil
+	}
+	intercept(ctx, "some data", uInfo, handler)
+
+	stupidTestShenanigans := fmt.Sprintf("%v", measures)
+	assert.NotNil(t, strings.Contains(stupidTestShenanigans, "something.blah.received"))
+	assert.NotNil(t, strings.Contains(stupidTestShenanigans, "something.blah.result::status::OK"))
+	assert.NotNil(t, strings.Contains(stupidTestShenanigans, "something.blah.time_ms"))
+}

--- a/contrib/grpc/interceptors_test.go
+++ b/contrib/grpc/interceptors_test.go
@@ -23,7 +23,7 @@ func TestUnaryRequest(t *testing.T) {
 	measures := appoptics.NewMeasurementSet()
 	intercept := UnaryServerInterceptor(measures)
 	ctx := context.Background()
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+	var handler grpc.UnaryHandler = func(ctx context.Context, req interface{}) (interface{}, error) {
 		return "something", nil
 	}
 	intercept(ctx, "some data", uInfo, handler)


### PR DESCRIPTION
* Adding a dir `contrib/grpc` to hold contributed (and contributed gRPC) stuff. Good name?
* Moving a gRPC interceptor from PT's `sawmill` project that creates AO metrics for gRPC calls. This only does the basics: counts of requests received, counts of status codes (broken out in tags) and time elapsed for non-streaming calls