### PR TITLE
Make tests run on Go 1.8

### DIFF
--- a/contrib/grpc/interceptors_test.go
+++ b/contrib/grpc/interceptors_test.go
@@ -1,18 +1,18 @@
 package interceptors
 
 import (
-	"context"
-	"testing"
-
-	"google.golang.org/grpc"
-	"github.com/appoptics/appoptics-api-go"
-	"github.com/stretchr/testify/assert"
 	"fmt"
 	"strings"
+	"testing"
+
+	"github.com/appoptics/appoptics-api-go"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 var (
-	srv = "server_full_of_testing"
+	srv   = "server_full_of_testing"
 	uInfo = &grpc.UnaryServerInfo{
 		FullMethod: "/something/blah",
 		Server:     srv,


### PR DESCRIPTION
This makes the project build and test on Go 1.8, which stopped working in #46.