### PR TITLE
Metrics API, error handling fix

### DIFF
--- a/appoptics_test/api_tokens_test.go
+++ b/appoptics_test/api_tokens_test.go
@@ -9,10 +9,7 @@ import (
 
 func TestApiTokensService_List(t *testing.T) {
 	apiTokenResponse, err := client.ApiTokensService().List()
-	if err != nil {
-		t.Errorf("error running List: %v", err)
-	}
-
+	assert.Nil(t, err)
 	query := apiTokenResponse.Query
 	firstToken := apiTokenResponse.ApiTokens[0]
 
@@ -30,10 +27,7 @@ func TestApiTokensService_List(t *testing.T) {
 
 func TestApiTokensService_Create(t *testing.T) {
 	apiToken, err := client.ApiTokensService().Create(&appoptics.ApiToken{})
-	if err != nil {
-		t.Errorf("error running Create: %v", err)
-	}
-
+	assert.Nil(t, err)
 	assert.Equal(t, "My New Token", *apiToken.Name)
 	assert.Equal(t, "24f9fb2134399595b91da1dcac39cb6eafc68a07fa08ad3d70892b7aad10e1cf", *apiToken.Token)
 	assert.Equal(t, true, *apiToken.Active)
@@ -42,6 +36,7 @@ func TestApiTokensService_Create(t *testing.T) {
 
 func TestApiTokensService_Retrieve(t *testing.T) {
 	apiTokenResponse, err := client.ApiTokensService().Retrieve("foobar")
+	assert.Nil(t, err)
 
 	query := apiTokenResponse.Query
 	firstToken := apiTokenResponse.ApiTokens[0]
@@ -64,11 +59,7 @@ func TestApiTokensService_Retrieve(t *testing.T) {
 
 func TestApiTokensService_Update(t *testing.T) {
 	apiToken, err := client.ApiTokensService().Update(&appoptics.ApiToken{})
-
-	if err != nil {
-		t.Errorf("error running Status: %v", err)
-	}
-
+	assert.Nil(t, err)
 	assert.Equal(t, "New Token Name", *apiToken.Name)
 	assert.Equal(t, "24f9fb2134399595b91da1dcac39cb6eafc68a07fa08ad3d70892b7aad10e1cf", *apiToken.Token)
 	assert.Equal(t, false, *apiToken.Active)

--- a/appoptics_test/metrics_handlers_test.go
+++ b/appoptics_test/metrics_handlers_test.go
@@ -5,6 +5,44 @@ import "net/http"
 func ListMetricsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		responseBody := `{
+  "query": {
+    "found": 2,
+    "length": 2,
+    "offset": 0,
+    "total": 2
+  },
+  "metrics": [
+    {
+      "name": "app_requests",
+      "display_name": "app_requests",
+      "description": "HTTP requests serviced by the app per-minute",
+      "period": 60,
+      "type": "gauge",
+      "attributes": {
+        "created_by_ua": "appoptics-metrics/0.7.4 (ruby; 1.9.3p194; x86_64-linux) direct-faraday/0.8.4",
+        "display_max": null,
+        "display_min": 0,
+        "display_stacked": true,
+        "display_units_long": "Requests",
+        "display_units_short": "reqs"
+      }
+    },
+    {
+      "name": "cpu_temp",
+      "display_name": "cpu_temp",
+      "description": "Current CPU temperature in Fahrenheit",
+      "period": 60,
+      "type": "gauge",
+      "attributes": {
+        "created_by_ua": "appoptics-metrics/0.7.4 (ruby; 1.9.3p194; x86_64-linux) direct-faraday/0.8.4",
+        "display_max": null,
+        "display_min": 0,
+        "display_stacked": true,
+        "display_units_long": "Fahrenheit",
+        "display_units_short": "°F"
+      }
+    }
+  ]
 }`
 		w.Write([]byte(responseBody))
 	}
@@ -15,9 +53,9 @@ func CreateMetricHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		responseBody := `{
   "name": "cpu.percent.used",
-  "display_name": null,
+  "display_name": "CPU Used",
   "type": "composite",
-  "description": null,
+  "description": "all the cpu used on the machine",
   "period": null,
   "source_lag": null,
   "composite": "s(\"cpu.percent.user\", {\"environment\" : \"prod\", \"service\": \"api\"})"

--- a/appoptics_test/metrics_handlers_test.go
+++ b/appoptics_test/metrics_handlers_test.go
@@ -1,0 +1,61 @@
+package appoptics_test
+
+import "net/http"
+
+func ListMetricsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		responseBody := `{
+}`
+		w.Write([]byte(responseBody))
+	}
+
+}
+
+func CreateMetricHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		responseBody := `{
+  "name": "cpu.percent.used",
+  "display_name": null,
+  "type": "composite",
+  "description": null,
+  "period": null,
+  "source_lag": null,
+  "composite": "s(\"cpu.percent.user\", {\"environment\" : \"prod\", \"service\": \"api\"})"
+}`
+		w.Write([]byte(responseBody))
+	}
+
+}
+
+func UpdateMetricHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+func RetrieveMetricHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		responseBody := `{
+  "name": "cpu_temp",
+  "display_name": "cpu_temp",
+  "description": "Current CPU temperature in Fahrenheit",
+  "period": 60,
+  "type": "gauge",
+  "attributes": {
+    "created_by_ua": "appoptics-metrics/0.7.4 (ruby; 1.9.3p194; x86_64-linux) direct-faraday/0.8.4",
+    "display_max": null,
+    "display_min": 0,
+    "display_stacked": true,
+    "display_units_long": "Fahrenheit",
+    "display_units_short": "°F"
+  }
+}`
+		w.Write([]byte(responseBody))
+	}
+}
+
+func DeleteMetricHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}
+}

--- a/appoptics_test/metrics_test.go
+++ b/appoptics_test/metrics_test.go
@@ -1,0 +1,1 @@
+package appoptics

--- a/appoptics_test/metrics_test.go
+++ b/appoptics_test/metrics_test.go
@@ -1,1 +1,72 @@
-package appoptics
+package appoptics_test
+
+import (
+	"testing"
+
+	"github.com/appoptics/appoptics-api-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsService_List(t *testing.T) {
+	apiMetricsResponse, err := client.MetricsService().List()
+
+	require.Nil(t, err)
+
+	query := apiMetricsResponse.Query
+
+	firstMetric := apiMetricsResponse.Metrics[0]
+	firstAttributes := firstMetric.Attributes
+
+	// Query
+	assert.Equal(t, 2, query.Found)
+	assert.Equal(t, 2, query.Length)
+	assert.Equal(t, 2, query.Total)
+
+	// Metric metadata
+	assert.Equal(t, "app_requests", firstMetric.Name)
+	assert.Equal(t, "app_requests", firstMetric.DisplayName)
+	assert.Equal(t, "HTTP requests serviced by the app per-minute", firstMetric.Description)
+	assert.Equal(t, 60, firstMetric.Period)
+	assert.Equal(t, "gauge", firstMetric.Type)
+
+	// Attributes
+	assert.Equal(t, "appoptics-metrics/0.7.4 (ruby; 1.9.3p194; x86_64-linux) direct-faraday/0.8.4", firstAttributes.CreatedByUA)
+	assert.Equal(t, float64(0), firstAttributes.DisplayMin)
+	assert.Equal(t, true, firstAttributes.DisplayStacked)
+	assert.Equal(t, "Requests", firstAttributes.DisplayUnitsLong)
+	assert.Equal(t, "reqs", firstAttributes.DisplayUnitsShort)
+
+}
+
+func TestMetricsService_Create(t *testing.T) {
+	apiMetricsResponse, err := client.MetricsService().Create(&appoptics.Metric{Name: "cpu.percent.used"})
+	require.Nil(t, err)
+
+	assert.Equal(t, "cpu.percent.used", apiMetricsResponse.Name)
+	assert.Equal(t, "CPU Used", apiMetricsResponse.DisplayName)
+	assert.Equal(t, "composite", apiMetricsResponse.Type)
+	assert.Equal(t, "all the cpu used on the machine", apiMetricsResponse.Description)
+}
+
+func TestMetricsService_Retrieve(t *testing.T) {
+	apiMetricsResponse, err := client.MetricsService().Retrieve("cpu.temp")
+
+	require.Nil(t, err)
+
+	assert.Equal(t, "cpu_temp", apiMetricsResponse.Name)
+	assert.Equal(t, "cpu_temp", apiMetricsResponse.DisplayName)
+	assert.Equal(t, "gauge", apiMetricsResponse.Type)
+}
+
+// Yes, this test doesn't really do anything
+func TestMetricsService_Update(t *testing.T) {
+	err := client.MetricsService().Update(&appoptics.MetricAttributes{})
+	require.Nil(t, err)
+}
+
+// Yes, this test doesn't really do anything
+func TestMetricsService_Delete(t *testing.T) {
+	err := client.MetricsService().Delete("cpu.temp")
+	require.Nil(t, err)
+}

--- a/appoptics_test/server_mux_test.go
+++ b/appoptics_test/server_mux_test.go
@@ -39,6 +39,11 @@ func NewServerTestMux() *mux.Router {
 	// Measurements
 
 	// Metrics
+	router.Handle("/v1/metrics", ListMetricsHandler()).Methods("GET")
+	router.Handle("/v1/metrics/{name}", CreateMetricHandler()).Methods("PUT")
+	router.Handle("/v1/metrics/{name}", RetrieveMetricHandler()).Methods("GET")
+	router.Handle("/v1/metrics", UpdateMetricHandler()).Methods("PUT")
+	router.Handle("/v1/metrics/", DeleteMetricHandler()).Methods("DELETE")
 
 	// Spaces
 	router.Handle("/v1/spaces", ListSpacesHandler()).Methods("GET")

--- a/client.go
+++ b/client.go
@@ -83,20 +83,17 @@ type ParamErrorMessage []map[string]string
 
 // Client implements ServiceAccessor
 type Client struct {
-	baseURL    *url.URL
-	httpClient httpClient
-	token      string
-
-	alertsService       AlertsCommunicator
-	annotationsService  AnnotationsCommunicator
-	apiTokensService    ApiTokensCommunicator
-	jobsService         JobsCommunicator
-	chartsService       ChartsCommunicator
-	measurementsService MeasurementsCommunicator
-	snapshotsService    SnapshotsCommunicator
-	spacesService       SpacesCommunicator
-	servicesService     ServicesCommunicator
-
+	baseURL                 *url.URL
+	httpClient              httpClient
+	token                   string
+	alertsService           AlertsCommunicator
+	annotationsService      AnnotationsCommunicator
+	apiTokensService        ApiTokensCommunicator
+	chartsService           ChartsCommunicator
+	measurementsService     MeasurementsCommunicator
+	metricsService          MetricsCommunicator
+	spacesService           SpacesCommunicator
+	servicesService         ServicesCommunicator
 	callerUserAgentFragment string
 }
 

--- a/client.go
+++ b/client.go
@@ -90,9 +90,11 @@ type Client struct {
 	annotationsService      AnnotationsCommunicator
 	apiTokensService        ApiTokensCommunicator
 	chartsService           ChartsCommunicator
+	jobsService             JobsCommunicator
 	measurementsService     MeasurementsCommunicator
 	metricsService          MetricsCommunicator
 	spacesService           SpacesCommunicator
+	snapshotsService        SnapshotsCommunicator
 	servicesService         ServicesCommunicator
 	callerUserAgentFragment string
 }
@@ -205,24 +207,14 @@ func (c *Client) ApiTokensService() ApiTokensCommunicator {
 	return c.apiTokensService
 }
 
-// JobsService represents the subset of the API that deals with Jobs
-func (c *Client) JobsService() JobsCommunicator {
-	return c.jobsService
-}
-
-// MeasurementsService represents the subset of the API that deals with Measurements
-func (c *Client) MeasurementsService() MeasurementsCommunicator {
-	return c.measurementsService
-}
-
-// SpacesService represents the subset of the API that deals with Spaces
-func (c *Client) SpacesService() SpacesCommunicator {
-	return c.spacesService
-}
-
 // ChartsService represents the subset of the API that deals with Charts
 func (c *Client) ChartsService() ChartsCommunicator {
 	return c.chartsService
+}
+
+// JobsService represents the subset of the API that deals with Jobs
+func (c *Client) JobsService() JobsCommunicator {
+	return c.jobsService
 }
 
 // MeasurementsService represents the subset of the API that deals with Measurements
@@ -235,14 +227,19 @@ func (c *Client) MetricsService() MetricsCommunicator {
 	return c.metricsService
 }
 
+// ServicesService represents the subset of the API that deals with Services
+func (c *Client) ServicesService() ServicesCommunicator {
+	return c.servicesService
+}
+
 // SnapshotsService represents the subset of the API that deals with Snapshots
 func (c *Client) SnapshotsService() SnapshotsCommunicator {
 	return c.snapshotsService
 }
 
-// ServicesService represents the subset of the API that deals with Services
-func (c *Client) ServicesService() ServicesCommunicator {
-	return c.servicesService
+// SpacesService represents the subset of the API that deals with Spaces
+func (c *Client) SpacesService() SpacesCommunicator {
+	return c.spacesService
 }
 
 // Error makes ErrorResponse satisfy the error interface and can be used to serialize error responses back to the httpClient

--- a/client.go
+++ b/client.go
@@ -53,6 +53,7 @@ type ServiceAccessor interface {
 	ChartsService() ChartsCommunicator
 	JobsService() JobsCommunicator
 	MeasurementsService() MeasurementsCommunicator
+	MetricsService() MetricsCommunicator
 	ServicesService() ServicesCommunicator
 	SnapshotsService() SnapshotsCommunicator
 	SpacesService() SpacesCommunicator
@@ -128,6 +129,7 @@ func NewClient(token string, opts ...func(*Client) error) *Client {
 	c.chartsService = NewChartsService(c)
 	c.jobsService = NewJobsService(c)
 	c.measurementsService = NewMeasurementsService(c)
+	c.metricsService = NewMetricsService(c)
 	c.servicesService = NewServiceService(c)
 	c.snapshotsService = NewSnapshotsService(c)
 	c.spacesService = NewSpacesService(c)
@@ -224,6 +226,16 @@ func (c *Client) SpacesService() SpacesCommunicator {
 // ChartsService represents the subset of the API that deals with Charts
 func (c *Client) ChartsService() ChartsCommunicator {
 	return c.chartsService
+}
+
+// MeasurementsService represents the subset of the API that deals with Measurements
+func (c *Client) MeasurementsService() MeasurementsCommunicator {
+	return c.measurementsService
+}
+
+// MetricsService represents the subset of the API that deals with Metrics
+func (c *Client) MetricsService() MetricsCommunicator {
+	return c.metricsService
 }
 
 // SnapshotsService represents the subset of the API that deals with Snapshots

--- a/client.go
+++ b/client.go
@@ -291,14 +291,20 @@ func clientVersionString() string {
 	return fmt.Sprintf("%s-v%s", clientIdentifier, Version())
 }
 
-// checkError creates an ErrorResponse from the http.Response.Body
+// checkError creates an ErrorResponse from the http.Response.Body, if there is one
 func checkError(resp *http.Response) error {
 	var errResponse ErrorResponse
 	if resp.StatusCode >= 400 {
-		dec := json.NewDecoder(resp.Body)
-		dec.Decode(&errResponse)
-		log.Printf("error: %+v\n", errResponse)
-		return &errResponse
+		if resp.ContentLength > 0 {
+			decoder := json.NewDecoder(resp.Body)
+			err := decoder.Decode(errResponse)
+
+			if err != nil {
+				return err
+			}
+			log.Debugf("error: %+v\n", errResponse)
+			return &errResponse
+		}
 	}
 	return nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -45,8 +45,8 @@ type MetricsCommunicator interface {
 	List() (*MetricsResponse, error)
 	Retrieve(string) (*Metric, error)
 	Create(*Metric) (*Metric, error)
-	Update(*Metric) (*Metric, error)
-	Delete(int) error
+	Update(*MetricAttributes) error
+	Delete(string) error
 }
 
 func NewMetricsService(c *Client) *MetricsService {

--- a/metrics.go
+++ b/metrics.go
@@ -2,7 +2,7 @@ package appoptics
 
 import "fmt"
 
-// Metric represents a Librato Metric.
+// Metric is an AppOptics Metric
 type Metric struct {
 	Name        string           `json:"name"`
 	Description string           `json:"description,omitempty"`
@@ -13,9 +13,9 @@ type Metric struct {
 	Attributes  MetricAttributes `json:"attributes,omitempty"`
 }
 
-// MetricAttributes are named attributes as key:value pairs.
+// MetricAttributes are key/value pairs of metadata about the Metric
 type MetricAttributes struct {
-	Color             *string     `json:"color,omitempty"`
+	Color             string      `json:"color,omitempty"`
 	DisplayMax        interface{} `json:"display_max,omitempty"`
 	DisplayMin        interface{} `json:"display_min,omitempty"`
 	DisplayUnitsLong  string      `json:"display_units_long,omitempty"`
@@ -33,6 +33,12 @@ type MetricsResponse struct {
 
 type MetricsService struct {
 	client *Client
+}
+
+// MetricUpdatePayload will apply the state represented by Attributes to the Metrics identified by Names
+type MetricUpdatePayload struct {
+	Names      []string         `json:"names"`
+	Attributes MetricAttributes `json:"attributes"`
 }
 
 type MetricsCommunicator interface {
@@ -98,8 +104,20 @@ func (ms *MetricsService) Create(m *Metric) (*Metric, error) {
 	return createdMetric, nil
 }
 
-func (ms *MetricsService) Update(m *Metric) (*MetricsResponse, error) {
-	return nil, nil
+func (ms *MetricsService) Update(mas *MetricAttributes) error {
+	req, err := ms.client.NewRequest("PUT", "metrics", mas)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = ms.client.Do(req, nil)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (ms *MetricsService) Delete(name string) error {

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,115 @@
+package appoptics
+
+import "fmt"
+
+// Metric represents a Librato Metric.
+type Metric struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description,omitempty"`
+	Type        string           `json:"type"`
+	Period      int              `json:"period,omitempty"`
+	DisplayName string           `json:"display_name,omitempty"`
+	Composite   string           `json:"composite,omitempty"`
+	Attributes  MetricAttributes `json:"attributes,omitempty"`
+}
+
+// MetricAttributes are named attributes as key:value pairs.
+type MetricAttributes struct {
+	Color             *string     `json:"color,omitempty"`
+	DisplayMax        interface{} `json:"display_max,omitempty"`
+	DisplayMin        interface{} `json:"display_min,omitempty"`
+	DisplayUnitsLong  string      `json:"display_units_long,omitempty"`
+	DisplayUnitsShort string      `json:"display_units_short,omitempty"`
+	DisplayStacked    bool        `json:"display_stacked,omitempty"`
+	CreatedByUA       string      `json:"created_by_ua,omitempty"`
+	GapDetection      bool        `json:"gap_detection,omitempty"`
+	Aggregate         bool        `json:"aggregate,omitempty"`
+}
+
+type MetricsResponse struct {
+	Query   QueryInfo `json:"query,omitempty"`
+	Metrics []*Metric `json:"metrics,omitempty"`
+}
+
+type MetricsService struct {
+	client *Client
+}
+
+type MetricsCommunicator interface {
+	List() (*MetricsResponse, error)
+	Retrieve(string) (*Metric, error)
+	Create(*Metric) (*Metric, error)
+	Update(*Metric) (*Metric, error)
+	Delete(int) error
+}
+
+func NewMetricsService(c *Client) *MetricsService {
+	return &MetricsService{c}
+}
+
+func (ms *MetricsService) List() (*MetricsResponse, error) {
+	req, err := ms.client.NewRequest("GET", "metrics", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	metricsResponse := &MetricsResponse{}
+
+	_, err = ms.client.Do(req, &metricsResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return metricsResponse, nil
+}
+
+func (ms *MetricsService) Retrieve(name string) (*Metric, error) {
+	metric := &Metric{}
+	path := fmt.Sprintf("metrics/%s", name)
+	req, err := ms.client.NewRequest("GET", path, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = ms.client.Do(req, metric)
+	if err != nil {
+		return nil, err
+	}
+
+	return metric, nil
+}
+
+func (ms *MetricsService) Create(m *Metric) (*Metric, error) {
+	path := fmt.Sprintf("metrics/%s", m.Name)
+	req, err := ms.client.NewRequest("PUT", path, m)
+	if err != nil {
+		return nil, err
+	}
+
+	createdMetric := &Metric{}
+
+	_, err = ms.client.Do(req, createdMetric)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdMetric, nil
+}
+
+func (ms *MetricsService) Update(m *Metric) (*MetricsResponse, error) {
+	return nil, nil
+}
+
+func (ms *MetricsService) Delete(name string) error {
+	path := fmt.Sprintf("metrics/%s", name)
+	req, err := ms.client.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = ms.client.Do(req, nil)
+
+	return err
+}


### PR DESCRIPTION
## What
* Support the Metrics portion of the API
* Don't attempt to parse an error body when the `ContentLength` is `0` (#59)

## Why
Metric pre-creation and metric management constituted the last bits of the API that weren't yet covered. This was overlooked before due to the fact that Metric creation is a side-effect of Measurement creation with a first-time Metric.