### PR TITLE
Differentiate alert request/response structs

### DIFF
--- a/_live-tests/alerts_test.go
+++ b/_live-tests/alerts_test.go
@@ -34,7 +34,7 @@ func TestAlerts(t *testing.T) {
 	defer client.ServicesService().Delete(service.ID)
 
 	t.Run("Create", func(t *testing.T) {
-		newAlert, err := client.AlertsService().Create(testAlert("test", metric.Name))
+		newAlert, err := client.AlertsService().Create(testAlertRequest("test", metric.Name))
 		require.Nil(t, err)
 		assert.Equal(t, testAlert("test", metric.Name).Name, newAlert.Name)
 		alert = newAlert
@@ -63,7 +63,9 @@ func TestAlerts(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		alert.Name = "other.name"
-		err := client.AlertsService().Update(alert)
+		newRequest := testAlertRequest(alert.Name, metric.Name)
+		newRequest.ID = alert.ID
+		err := client.AlertsService().Update(newRequest)
 		assert.Nil(t, err)
 	})
 
@@ -71,6 +73,21 @@ func TestAlerts(t *testing.T) {
 		err := client.AlertsService().Delete(alert.ID)
 		require.Nil(t, err)
 	})
+}
+
+func testAlertRequest(n, metricName string) *appoptics.AlertRequest {
+	alertName := fmt.Sprintf("%s-%s", TestPrefix, n)
+	return &appoptics.AlertRequest{
+		Name:        alertName,
+		Description: "A Test Alert",
+		Conditions: []*appoptics.AlertCondition{
+			{
+				Type:       "above",
+				MetricName: metricName,
+				Threshold:  200,
+			},
+		},
+	}
 }
 
 func testAlert(n, metricName string) *appoptics.Alert {

--- a/alerts.go
+++ b/alerts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// Alert defines a policy for sending alarms to services when conditions are met
 type Alert struct {
 	ID           int                    `json:"id,omitempty"`
 	Name         string                 `json:"name,omitempty"`
@@ -12,7 +13,21 @@ type Alert struct {
 	RearmSeconds int                    `json:"rearm_seconds,omitempty"`
 	Conditions   []*AlertCondition      `json:"conditions,omitempty"`
 	Attributes   map[string]interface{} `json:"attributes,omitempty"`
-	Services     []*Service             `json:"services,omitempty"` // correspond to IDs of Service objects
+	Services     []*Service             `json:"services,omitempty"`
+	CreatedAt    int                    `json:"created_at,omitempty"`
+	UpdatedAt    int                    `json:"updated_at,omitempty"`
+}
+
+// AlertRequest is identical to Alert except for the fact that Services is a []int in AlertRequest
+type AlertRequest struct {
+	ID           int                    `json:"id,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Active       bool                   `json:"active,omitempty"`
+	RearmSeconds int                    `json:"rearm_seconds,omitempty"`
+	Conditions   []*AlertCondition      `json:"conditions,omitempty"`
+	Attributes   map[string]interface{} `json:"attributes,omitempty"`
+	Services     []int                  `json:"services,omitempty"` // correspond to IDs of Service objects
 	CreatedAt    int                    `json:"created_at,omitempty"`
 	UpdatedAt    int                    `json:"updated_at,omitempty"`
 }
@@ -33,7 +48,7 @@ type AlertStatus struct {
 	Status string `json:"status,omitempty"`
 }
 
-type AlertsResponse struct {
+type AlertsListResponse struct {
 	Query  QueryInfo `json:"query,omitempty"`
 	Alerts []*Alert  `json:"alerts,omitempty"`
 }
@@ -43,10 +58,10 @@ type AlertsService struct {
 }
 
 type AlertsCommunicator interface {
-	List() (*AlertsResponse, error)
+	List() (*AlertsListResponse, error)
 	Retrieve(int) (*Alert, error)
-	Create(*Alert) (*Alert, error)
-	Update(*Alert) error
+	Create(*AlertRequest) (*Alert, error)
+	Update(*AlertRequest) error
 	AssociateToService(int, int) error
 	DisassociateFromService(alertId, serviceId int) error
 	Delete(int) error
@@ -58,13 +73,13 @@ func NewAlertsService(c *Client) *AlertsService {
 }
 
 // List retrieves all Alerts
-func (as *AlertsService) List() (*AlertsResponse, error) {
+func (as *AlertsService) List() (*AlertsListResponse, error) {
 	req, err := as.client.NewRequest("GET", "alerts", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	alertsResponse := &AlertsResponse{}
+	alertsResponse := &AlertsListResponse{}
 
 	_, err = as.client.Do(req, &alertsResponse)
 
@@ -94,7 +109,7 @@ func (as *AlertsService) Retrieve(id int) (*Alert, error) {
 }
 
 // Create creates the Alert
-func (as *AlertsService) Create(a *Alert) (*Alert, error) {
+func (as *AlertsService) Create(a *AlertRequest) (*Alert, error) {
 	req, err := as.client.NewRequest("POST", "alerts", a)
 	if err != nil {
 		return nil, err
@@ -111,7 +126,7 @@ func (as *AlertsService) Create(a *Alert) (*Alert, error) {
 }
 
 // Update updates the Alert
-func (as *AlertsService) Update(a *Alert) error {
+func (as *AlertsService) Update(a *AlertRequest) error {
 	path := fmt.Sprintf("alerts/%d", a.ID)
 	req, err := as.client.NewRequest("PUT", path, a)
 	if err != nil {

--- a/appoptics_test/alerts_test.go
+++ b/appoptics_test/alerts_test.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/appoptics/appoptics-api-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAlertsService_List(t *testing.T) {
 	alertResponse, err := client.AlertsService().List()
-	if err != nil {
-		t.Errorf("error running List: %v", err)
-	}
+	require.Nil(t, err)
 
 	query := alertResponse.Query
 	alert := alertResponse.Alerts[0]
@@ -45,7 +44,7 @@ func TestAlertsService_List(t *testing.T) {
 }
 
 func TestAlertsService_Create(t *testing.T) {
-	alert, err := client.AlertsService().Create(&appoptics.Alert{})
+	alert, err := client.AlertsService().Create(&appoptics.AlertRequest{})
 	if err != nil {
 		t.Errorf("error running Create: %v", err)
 	}
@@ -66,12 +65,9 @@ func TestAlertsService_Create(t *testing.T) {
 
 func TestAlertsService_Retrieve(t *testing.T) {
 	alert, err := client.AlertsService().Retrieve(123)
-
-	if err != nil {
-		t.Errorf("error running Retrieve: %v", err)
-	}
-
+	require.Nil(t, err)
 	service := alert.Services[0]
+
 	serviceSetting := service.Settings
 
 	// Alert


### PR DESCRIPTION
## What
A new struct to accommodate the fact that `Services` is a different type depending on what part of the `Alerts` API you're hitting (basically requests contain IDs and responses contain full objects, but both at the same key).

## Why
* To support the burgeoning TF provider
* To fix a bug