### PR TITLE
Reuse a single http.Client instance

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,6 +41,13 @@ var (
 	regexpIllegalNameChars = regexp.MustCompile("[^A-Za-z0-9.:_-]") // from https://www.AppOptics.com/docs/api/#measurements
 	// ErrBadStatus is returned if the AppOptics API returns a non-200 error code.
 	ErrBadStatus = errors.New("Received non-OK status from AppOptics POST")
+	client = &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: 4,
+			IdleConnTimeout:     30 * time.Second,
+		},
+	}
 )
 
 func Version() string {
@@ -117,13 +124,7 @@ func NewClient(token string, opts ...func(*Client) error) *Client {
 	c := &Client{
 		token:   token,
 		baseURL: baseURL,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-			Transport: &http.Transport{
-				MaxIdleConnsPerHost: 4,
-				IdleConnTimeout:     30 * time.Second,
-			},
-		},
+		httpClient: client,
 	}
 
 	c.alertsService = NewAlertsService(c)

--- a/client.go
+++ b/client.go
@@ -43,10 +43,6 @@ var (
 	ErrBadStatus = errors.New("Received non-OK status from AppOptics POST")
 	client = &http.Client{
 		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConnsPerHost: 4,
-			IdleConnTimeout:     30 * time.Second,
-		},
 	}
 )
 


### PR DESCRIPTION
This allows applications that make many requests to AppOptics to make
use of net/http's connection pooling and persistent connections.