### PR TITLE
Remove dead code

### DIFF
--- a/client.go
+++ b/client.go
@@ -276,10 +276,6 @@ func (c *Client) Do(req *http.Request, respData interface{}) (*http.Response, er
 
 	defer resp.Body.Close()
 	if respData != nil {
-		if writer, ok := respData.(io.Writer); ok {
-			_, err := io.Copy(writer, resp.Body)
-			return resp, err
-		}
 		err = json.NewDecoder(resp.Body).Decode(respData)
 	}
 


### PR DESCRIPTION
## What
Remove the ability to have responses be handled by an `io.Writer`

## Why
This was in the original 3rd party Librato lib, so it got ported into client code but never ended up getting used in subsequent lib code here.