### PR TITLE
Include 0 values in alert threshold payloads

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -36,7 +36,7 @@ type AlertCondition struct {
 	ID              int     `json:"id,omitempty"`
 	Type            string  `json:"type,omitempty"`
 	MetricName      string  `json:"metric_name,omitempty"`
-	Threshold       float64 `json:"threshold,omitempty"`
+	Threshold       float64 `json:"threshold"`
 	SummaryFunction string  `json:"summary_function,omitempty"`
 	Duration        int     `json:"duration,omitempty"`
 	DetectReset     bool    `json:"detect_reset,omitempty"`


### PR DESCRIPTION
This change ensures that clients can create alerts with a threshold of 0. Prior to this change, thresholds of 0 would be omitted from the JSON payload for creating or updating alerts, resulting in a validation error (400 Bad Request) from the API.

See #69