### PR TITLE
ErrorResponse.Error() now returns something useful

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,23 @@
+package appoptics
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ErrorResponse represents the response body returned when the API reports an error
+type ErrorResponse struct {
+	Errors   interface{} `json:"errors"`
+	Status string `json:"status"`
+	Response *http.Response
+}
+
+// Error makes ErrorResponse satisfy the error interface and can be used to serialize error responses back to the httpClient
+func (e *ErrorResponse) Error() string {
+	errorData, _ := json.Marshal(e.Errors)
+	return fmt.Sprintf("%s - %s", e.Status, string(errorData))
+}
+
+
+

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,44 @@
+package appoptics
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+var (
+	ErrorRequestBodyUnauthorized = `{
+	"errors":{
+		"request":["This token is not permitted to perform this action on this resource"]
+	}
+}
+`
+)
+
+func TestErrorResponse_Error(t *testing.T) {
+	errResp := &ErrorResponse{}
+	body := strings.NewReader(ErrorRequestBodyUnauthorized)
+	decoder := json.NewDecoder(body)
+	decodeErr := decoder.Decode(errResp)
+
+	t.Run("it decodes without error", func(t *testing.T) {
+		require.NoError(t, decodeErr)
+	})
+
+	t.Run("it holds detailed error information", func(t *testing.T) {
+		v := errResp.Errors.(map[string]interface{})
+		mapV := v["request"].([]interface{})
+		sVal := mapV[0].(string)
+		assert.Equal(t, "This token is not permitted to perform this action on this resource", sVal)
+	})
+	
+	t.Run("it places error information in Error() output", func(t *testing.T) {
+		errResp.Status = "403 Forbidden"
+		actual := `403 Forbidden - {"request":["This token is not permitted to perform this action on this resource"]}`
+		assert.Equal(t, errResp.Error(), actual)
+	} )
+}
+
+


### PR DESCRIPTION
 Fixes #71

## What
Fixes an issue where clients depending on `ErrorResponse.Error()` (such as Terraform Providers) won't just see a blank string.

## Why
CLI tools depending on this client need to have something useful in the string version of returned errors.