### PR TITLE
Metric tag serialization

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -3,6 +3,7 @@ package appoptics
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -29,10 +30,14 @@ func MetricWithTags(name string, tags map[string]interface{}) string {
 	if tags == nil {
 		return name
 	}
-
 	b := bytes.NewBufferString(name)
-
-	for k, v := range tags {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := tags[k]
 		b.WriteString(MetricTagSeparator)
 		b.WriteString(k)
 		b.WriteString(MetricTagSeparator)

--- a/tags.go
+++ b/tags.go
@@ -14,6 +14,17 @@ type Tag struct {
 	Dynamic bool     `json:"dynamic,omitempty"`
 }
 
+// MetricTagSeparator is used by MetricWithTags as a separator when serializing
+// the metric name and tags as a key for aggregation with measurements matching
+// the same metric name and tags.
+//
+// Users can build these strings internally if desired, using a format like below,
+// using MetricTagSeparator in place of the pipes ("|"):
+// - "metric_name"
+// - "metric_name|tag_1_key|tag_1_value"
+// - "metric_name|tag_1_key|tag_1_value|tag_2_key|tag_2_value" ...
+const MetricTagSeparator = "\x00"
+
 func MetricWithTags(name string, tags map[string]interface{}) string {
 	if tags == nil {
 		return name
@@ -22,9 +33,9 @@ func MetricWithTags(name string, tags map[string]interface{}) string {
 	b := bytes.NewBufferString(name)
 
 	for k, v := range tags {
-		b.WriteString("::")
+		b.WriteString(MetricTagSeparator)
 		b.WriteString(k)
-		b.WriteString("::")
+		b.WriteString(MetricTagSeparator)
 		b.WriteString(fmt.Sprint(v))
 	}
 
@@ -33,7 +44,7 @@ func MetricWithTags(name string, tags map[string]interface{}) string {
 
 func parseMeasurementKey(key string) (string, map[string]string) {
 	var (
-		nameParts  = strings.Split(key, "::")
+		nameParts  = strings.Split(key, MetricTagSeparator)
 		metricName = nameParts[0]
 	)
 

--- a/tags.go
+++ b/tags.go
@@ -19,10 +19,11 @@ type Tag struct {
 // the metric name and tags as a key for aggregation with measurements matching
 // the same metric name and tags.
 //
-// Users can build these strings internally if desired, using a format like below:
+// Users can build these strings internally if desired, using a format like below,
+// substituting MetricTagSeparator for the "|" pipes:
 // - "metric_name"
-// - "metric_name\x00tag_1_key\x00tag_1_value"
-// - "metric_name\x00tag_1_key\x00tag_1_value\x00tag_2_key\x00tag_2_value" ...
+// - "metric_name|tag_1_key|tag_1_value"
+// - "metric_name|tag_1_key|tag_1_value|tag_2_key|tag_2_value" ...
 const MetricTagSeparator = "\x00"
 
 func MetricWithTags(name string, tags map[string]interface{}) string {

--- a/tags.go
+++ b/tags.go
@@ -19,11 +19,10 @@ type Tag struct {
 // the metric name and tags as a key for aggregation with measurements matching
 // the same metric name and tags.
 //
-// Users can build these strings internally if desired, using a format like below,
-// using MetricTagSeparator in place of the pipes ("|"):
+// Users can build these strings internally if desired, using a format like below:
 // - "metric_name"
-// - "metric_name|tag_1_key|tag_1_value"
-// - "metric_name|tag_1_key|tag_1_value|tag_2_key|tag_2_value" ...
+// - "metric_name\x00tag_1_key\x00tag_1_value"
+// - "metric_name\x00tag_1_key\x00tag_1_value\x00tag_2_key\x00tag_2_value" ...
 const MetricTagSeparator = "\x00"
 
 func MetricWithTags(name string, tags map[string]interface{}) string {


### PR DESCRIPTION
This PR modifies MetricWithTags so that the serialized name+tags string is consistent from one call to the next. It now appends the tags in sorted order by tag name.

This also changes the metric tag separator from "::" to "\x00", which prevents breakage when the metric name, tag name, or tag values include "::".

This fixes #10.

Internal tracking: OY-3963